### PR TITLE
Fixed issue with modifiers and cleaned up code

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,3 +1,5 @@
+#include <X11/keysymdef.h>
+
 static const char *background_color = "#3e3e3e";
 static const char *border_color = "#ececec";
 static const char *font_color = "#ececec";
@@ -15,5 +17,5 @@ enum corners corner = TOP_RIGHT;
 
 static const unsigned int duration = 5; /* in seconds */
 
-#define KEY "q" // Delete this line to disable dismiss with shortcut
-#define MOD Mod1Mask
+#define SHORTCUT_KEY XK_space // Delete this line to disable dismiss with shortcut
+#define SHORTCUT_MOD ControlMask

--- a/herbe.c
+++ b/herbe.c
@@ -136,8 +136,15 @@ int main(int argc, char *argv[])
 	XftDraw *draw = XftDrawCreate(display, window, visual, colormap);
 	XftColorAllocName(display, visual, colormap, font_color, &color);
 
-	#ifdef KEY
-		XGrabKey(display, XKeysymToKeycode(display, XStringToKeysym(KEY)), MOD, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+	#ifdef SHORTCUT_KEY
+		XGrabKey(display, XKeysymToKeycode(display, SHORTCUT_KEY), SHORTCUT_MOD, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+		XGrabKey(display, XKeysymToKeycode(display, SHORTCUT_KEY), SHORTCUT_MOD | LockMask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+		XGrabKey(display, XKeysymToKeycode(display, SHORTCUT_KEY), SHORTCUT_MOD | Mod2Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+		XGrabKey(display, XKeysymToKeycode(display, SHORTCUT_KEY), SHORTCUT_MOD | Mod3Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+		XGrabKey(display, XKeysymToKeycode(display, SHORTCUT_KEY), SHORTCUT_MOD | LockMask | Mod2Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+		XGrabKey(display, XKeysymToKeycode(display, SHORTCUT_KEY), SHORTCUT_MOD | LockMask | Mod3Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+		XGrabKey(display, XKeysymToKeycode(display, SHORTCUT_KEY), SHORTCUT_MOD | Mod2Mask | Mod3Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
+		XGrabKey(display, XKeysymToKeycode(display, SHORTCUT_KEY), SHORTCUT_MOD | LockMask | Mod2Mask | Mod3Mask, DefaultRootWindow(display), True, GrabModeAsync, GrabModeAsync);
 	#endif
 
 	XSelectInput(display, window, ExposureMask | ButtonPress);


### PR DESCRIPTION
Other modifiers like NumLock and Scroll Lock or Caps Lock also count
towards the Modifier section and must therefore be included in the modifiers as well.
Mod1Mask is for NumLock and Mod2Mask is for Scroll Lock according to this source:
https://stackoverflow.com/a/29001687

I also made the code slightly more X11 idiomatic by using X11 keysyms rather than strings, which have less functionality. All keysyms are defined in <X11/keysymdef.h> and so are not difficult to find. This also matches other suckless tools.