### PR TITLE
Fixed new line character still showing up.

### DIFF
--- a/herbe.c
+++ b/herbe.c
@@ -125,6 +125,8 @@ int main(int argc, char *argv[])
 			if (!words[num_of_lines])
 				die("malloc failed");
 			strncpy(words[num_of_lines], body, eol);
+			if (eol >= 1 && words[num_of_lines][eol-1] == '\n')
+				words[num_of_lines][eol-1] = '\0';
 			words[num_of_lines][eol] = '\0';
 		}
 	}


### PR DESCRIPTION
Your previous patch correctly makes the line split on a literal new line, but it still drew the new line in addition to splitting the line. This patch overwrites the new line character with null character, stopping the drawing.