### PR TITLE
SIGUSR1 only dismisses active notification

### DIFF
--- a/herbe.c
+++ b/herbe.c
@@ -78,6 +78,7 @@ int main(int argc, char *argv[])
 	if (argc == 1)
 		die("Usage: %s body", argv[0]);
 
+	signal(SIGUSR1, SIG_IGN);
 	signal(SIGALRM, expire);
 	signal(SIGTERM, expire);
 	signal(SIGINT, expire);
@@ -155,6 +156,8 @@ int main(int argc, char *argv[])
 
 	sem_t *mutex = sem_open("/herbe", O_CREAT, 0644, 1);
 	sem_wait(mutex);
+
+	signal(SIGUSR1, expire);
 
 	if (duration != 0)
 		alarm(duration);


### PR DESCRIPTION
This builds upon the commit where herbe waits for the semaphore, it now waits to enable SIGUSR1 until it acquires the lock, meaning that `pkill -SIGUSR1 herbe` will now only dismiss the active notification.