### PR TITLE
patch: Xresources

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -2,18 +2,18 @@ static const char *background_color = "#3e3e3e";
 static const char *border_color = "#ececec";
 static const char *font_color = "#ececec";
 static const char *font_pattern = "monospace:size=10";
-static const unsigned line_spacing = 5;
-static const unsigned int padding = 15;
+static unsigned line_spacing = 5;
+static unsigned int padding = 15;
 
-static const unsigned int width = 450;
-static const unsigned int border_size = 2;
-static const unsigned int pos_x = 30;
-static const unsigned int pos_y = 60;
+static unsigned int width = 450;
+static unsigned int border_size = 2;
+static unsigned int pos_x = 30;
+static unsigned int pos_y = 60;
 
 enum corners { TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT };
 enum corners corner = TOP_RIGHT;
 
-static const unsigned int duration = 5; /* in seconds */
+static unsigned int duration = 5; /* in seconds */
 
 #define DISMISS_BUTTON Button1
 #define ACTION_BUTTON Button3

--- a/herbe.c
+++ b/herbe.c
@@ -1,5 +1,6 @@
 #include <X11/Xlib.h>
 #include <X11/Xft/Xft.h>
+#include <X11/Xresource.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
@@ -14,6 +15,13 @@
 #define EXIT_ACTION 0
 #define EXIT_FAIL 1
 #define EXIT_DISMISS 2
+
+#define XRES_STR(name)                                        \
+	if (XrmGetResource(db, "herbe." #name, "*", &type, &val)) \
+	name = val.addr
+#define XRES_INT(name)                                        \
+	if (XrmGetResource(db, "herbe." #name, "*", &type, &val)) \
+	name = strtoul(val.addr, 0, 10)
 
 Display *display;
 Window window;
@@ -106,6 +114,28 @@ int main(int argc, char *argv[])
 
 	if (!(display = XOpenDisplay(0)))
 		die("Cannot open display");
+
+	XrmInitialize();
+
+	char *res_man = XResourceManagerString(display);
+	XrmDatabase db = XrmGetStringDatabase(res_man);
+
+	char *type;
+	XrmValue val;
+
+	XRES_STR(background_color);
+	XRES_STR(border_color);
+	XRES_STR(font_color);
+	XRES_STR(font_pattern);
+
+	XRES_INT(line_spacing);
+	XRES_INT(padding);
+	XRES_INT(width);
+	XRES_INT(border_size);
+	XRES_INT(pos_x);
+	XRES_INT(pos_y);
+	XRES_INT(corner);
+	XRES_INT(duration);
 
 	int screen = DefaultScreen(display);
 	Visual *visual = DefaultVisual(display, screen);
@@ -214,6 +244,7 @@ int main(int argc, char *argv[])
 	XftDrawDestroy(draw);
 	XftColorFree(display, visual, colormap, &color);
 	XftFontClose(display, font);
+	XrmDestroyDatabase(db);
 	XCloseDisplay(display);
 
 	return exit_code;


### PR DESCRIPTION
## Description
Allows loading settings from `~/.Xresources`. This removes the need to compile from source (except for patching).

All settings are supported except `DISMISS_BUTTON` and `ACTION_BUTTON` (will add eventually, comment if interested).

Names of resources are exactly the same as variable names in `config.def.h`. Settings not found in `~/.Xresources` will be set to their default value taken from `config.def.h`.

Example `~./Xresources` file copying default settings:
```
herbe.background_color: #3e3e3e
herbe.border_color: #ececec
herbe.font_color: #ececec
herbe.font_pattern: monospace:size=10
herbe.line_spacing: 5
herbe.padding: 15
herbe.width: 450
herbe.border_size: 2
herbe.pos_x: 30
herbe.pos_y: 60
! 0 = TOP_LEFT, 1 = TOP_RIGHT, 2 = BOTTOM_LEFT, 3 = BOTTOM_RIGHT
herbe.corner: 1
herbe.duration: 5
```
Load with:
```shell
$ xrdb ~/.Xresources
```

## Download
https://patch-diff.githubusercontent.com/raw/dudik/herbe/pull/11.diff