### PR TITLE
patch: Add option to use primary monitor instead of root screen dimensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ config.h: config.def.h
 	cp config.def.h config.h
 
 herbe: herbe.c config.h
-	$(CC) herbe.c $(CFLAGS) -o herbe
+	$(CC) herbe.c $(CFLAGS) -o herbe -lXrandr
 
 install: herbe
 	mkdir -p ${DESTDIR}${PREFIX}/bin

--- a/config.def.h
+++ b/config.def.h
@@ -4,6 +4,7 @@ static const char *font_color = "#ececec";
 static const char *font_pattern = "monospace:size=10";
 static const unsigned line_spacing = 5;
 static const unsigned int padding = 15;
+static const int use_primary_monitor = 0;
 
 static const unsigned int width = 450;
 static const unsigned int border_size = 2;


### PR DESCRIPTION
Added option to use primary monitor instead root screen to determine
where to place notifications. This adds an Xrandr dependency.
Closes: #20 

### Download
https://patch-diff.githubusercontent.com/raw/dudik/herbe/pull/21.diff