### PR TITLE
Added an array with signals and added two iterations in main.

### DIFF
--- a/herbe.c
+++ b/herbe.c
@@ -15,9 +15,14 @@
 #define EXIT_FAIL 1
 #define EXIT_DISMISS 2
 
+#define LENGTH(X) (sizeof X / sizeof X[0])
+
 Display *display;
 Window window;
 int exit_code = EXIT_DISMISS;
+
+int signals_ignore[] = {SIGALRM, SIGTERM, SIGINT,};
+int signals_expire[] = {SIGUSR1, SIGUSR2};
 
 static void die(const char *format, ...)
 {
@@ -97,12 +102,11 @@ int main(int argc, char *argv[])
 	act_ignore.sa_flags = 0;
 	sigemptyset(&act_ignore.sa_mask);
 
-	sigaction(SIGALRM, &act_expire, 0);
-	sigaction(SIGTERM, &act_expire, 0);
-	sigaction(SIGINT, &act_expire, 0);
+	for (int i = 0; i < (int)LENGTH(signals_ignore); i++)
+		sigaction(signals_ignore[i], &act_ignore, 0);
 
-	sigaction(SIGUSR1, &act_ignore, 0);
-	sigaction(SIGUSR2, &act_ignore, 0);
+	for (int i = 0; i < (int)LENGTH(signals_ignore); i++)
+		sigaction(signals_expire[i], &act_ignore, 0);
 
 	if (!(display = XOpenDisplay(0)))
 		die("Cannot open display");

--- a/herbe.c
+++ b/herbe.c
@@ -102,10 +102,10 @@ int main(int argc, char *argv[])
 	act_ignore.sa_flags = 0;
 	sigemptyset(&act_ignore.sa_mask);
 
-	for (int i = 0; i < (int)LENGTH(signals_ignore); i++)
+	for (unsigned int i = 0; i < LENGTH(signals_ignore); i++)
 		sigaction(signals_ignore[i], &act_ignore, 0);
 
-	for (int i = 0; i < (int)LENGTH(signals_ignore); i++)
+	for (unsinged int i = 0; i < LENGTH(signals_ignore); i++)
 		sigaction(signals_expire[i], &act_ignore, 0);
 
 	if (!(display = XOpenDisplay(0)))

--- a/herbe.c
+++ b/herbe.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
 	for (unsigned int i = 0; i < LENGTH(signals_ignore); i++)
 		sigaction(signals_ignore[i], &act_ignore, 0);
 
-	for (unsinged int i = 0; i < LENGTH(signals_ignore); i++)
+	for (unsigned int i = 0; i < LENGTH(signals_ignore); i++)
 		sigaction(signals_expire[i], &act_ignore, 0);
 
 	if (!(display = XOpenDisplay(0)))


### PR DESCRIPTION
 These two iterations loop through signals_ignore and signals_expire. Signals_ignore holds signals that call act_ignore and signals_expire holds signals that call act_expire. Signals can be easily added and there is less repetition.

I think that this method of signal activation is simpler. Anything that simplifies main() imo is the preferable solution.

So rather than having something like this:
```C
/* run a function with different arguments each time.  */
do_something(x1);
do_something(x2);
do_something(x3);
do_something(x4);
```
My merge aims for a solution like this:
```C
/* this macro is more concise than just putting sizeof(array) / [...] */
#define LENGTH(X) (sizeof X / sizeof X[0])

[ ... ]

/* declare things as array, we can easily add more things */
int things[] = {x1, x2, x3, x4};

/* iterate through things and run do_something with things[i] as first argument.  */
for (int i = 0; i < LENGTH(things); i++)
        do_something(things[i]);

[ ... ]
```
If this gets accepted, I will also make more changes not unlike these to simplify this program.