### PR TITLE
Add projects integrating herbe to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,6 @@ herbe is configured at compile-time by editing `config.h`. Every option should b
 
 ## Contribute
 If you want to report a bug or you have a feature request, feel free to [open an issue](https://github.com/dudik/herbe/issues).
+
+## Projects with herbe integration
+- [qutebrowser](https://qutebrowser.org/) supports showing web notifications via herbe, via the `content.notifications.presenter` setting.


### PR DESCRIPTION
Hey! :wave: I added herbe support to [qutebrowser](https://www.qutebrowser.org/) after some users [mentioned using it](https://www.reddit.com/r/qutebrowser/comments/md15cj/please_show_me_your_notification_daemons/) when I asked them what notification daemons they were using :slightly_smiling_face: 

Since it [was relatively easy](https://github.com/qutebrowser/qutebrowser/blob/9530991425bb205623aedf2b74615312a071cfc1/qutebrowser/browser/webengine/notification.py#L530-L629) to add support, I thought "why not" and did so.

If you'd prefer not having this in the readme, that's completely fine as well of course - I admit this is shameless self promotion (but I also just wanted to let you know about it)!