### PR TITLE
stop overwriting config.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CC ?= cc
 
 all: herbe
 
-config.h: config.def.h
+config.h:
 	cp config.def.h config.h
 
 herbe: herbe.c config.h


### PR DESCRIPTION
See commit message for relevant comments.
Additional context:
I was trying to figure out why my ebuild for building herbe on gentoo wasn't applying my updated config.h and I found that due to the way the savedconfig eclass works the config.h file always ends up having an older timestamp than the checked-out src files.

Regardless, and as I mentioned in the commit, config.h should never be replaced by config.def.h. It should only be created if it doesn't already exist. Look to any of the suckless Makefiles and you will see that config.h never depends on config.def.h (though it is understandable as to why you would think it should). Eg: https://git.suckless.org/dwm/file/Makefile.html#l22