### PR TITLE
replace dangerous malloc and realloc usage with reallocarray

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -Wextra -pedantic -lX11 -lXft -I/usr/include/freetype2 -pthread
+CFLAGS = -Wall -Wextra -pedantic -lX11 -lXft -I/usr/include/freetype2 -pthread -D_DEFAULT_SOURCE
 
 PREFIX ?= /usr/local
 CC ?= cc


### PR DESCRIPTION
unchecked multiplications in the malloc and realloc args are a dangerous C
classic. they needed to be fixed.

also this fix allocates the exact number of needed lines instead of 5
to start with and an extra 5 everytime more are needed.