### PR TITLE
Makefile: Respect CFLAGS and LDFLAGS and some changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ HERBE_CFLAGS = -Wall -Wextra -pedantic -lX11 -lXft -I/usr/include/freetype2 -pth
 all: herbe
 
 config.h: config.def.h
-	cp -f config.def.h config.h
+	cp config.def.h config.h
 
 herbe: herbe.c config.h
 	$(CC) herbe.c $(CFLAGS) $(HERBE_CFLAGS) $(LDFLAGS) -o herbe
 
 install: herbe
-	install -d ${DESTDIR}${PREFIX}/bin
-	install -m 755 herbe ${DESTDIR}${PREFIX}/bin
+	mkdir -p ${DESTDIR}${PREFIX}/bin
+	cp -f herbe ${DESTDIR}${PREFIX}/bin
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/herbe

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
-CFLAGS = -Wall -Wextra -pedantic -lX11 -lXft -I/usr/include/freetype2 -pthread
-
-PREFIX ?= /usr/local
 CC ?= cc
+PREFIX ?= /usr/local
+
+HERBE_CFLAGS = -Wall -Wextra -pedantic -lX11 -lXft -I/usr/include/freetype2 -pthread
 
 all: herbe
 
 config.h: config.def.h
-	cp config.def.h config.h
+	cp -f config.def.h config.h
 
 herbe: herbe.c config.h
-	$(CC) herbe.c $(CFLAGS) -o herbe
+	$(CC) herbe.c $(CFLAGS) $(HERBE_CFLAGS) $(LDFLAGS) -o herbe
 
 install: herbe
-	mkdir -p ${DESTDIR}${PREFIX}/bin
-	cp -f herbe ${DESTDIR}${PREFIX}/bin
+	install -d ${DESTDIR}${PREFIX}/bin
+	install -m 755 herbe ${DESTDIR}${PREFIX}/bin
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/herbe


### PR DESCRIPTION
```
Use `install` instead of `mkdir` and `cp` for installation.
```

NVM, https://github.com/dudik/herbe/pull/37/commits/5a864e11273114138fcdc60ebc73c8b9c559c4df.