### PR TITLE
Fix linebreak for unicode symbols

### DIFF
--- a/herbe.c
+++ b/herbe.c
@@ -56,6 +56,9 @@ int get_max_len(char *string, XftFont *font, int max_text_width)
 			return ++i;
 		}
 
+	while (eol && (string[eol] & 0xC0) == 0x80)
+		--eol;
+
 	if (info.width <= max_text_width)
 		return eol;
 


### PR DESCRIPTION
When using unicode symbols that consist of more than one byte (non-ascii), the line break will most of the time happen within a byte sequence and break the rest of the line. This checks if the byte is a "tail byte" (starting with 10) and decrements in this case, because the line break should happen before a starting byte.